### PR TITLE
Add pc anywhere to gen4

### DIFF
--- a/src/field/ev_check.c
+++ b/src/field/ev_check.c
@@ -181,6 +181,7 @@ static void ClearRequest( EV_REQUEST * req )
 	req->PushCheck  = FALSE;
 	req->MoveCheck  = FALSE;
 	req->FloatCheck = FALSE;
+	req->OpenPCCheck = FALSE;
 
 	req->DebugMenu   = FALSE;
 	req->DebugBattle = FALSE;
@@ -233,6 +234,9 @@ void SetRequest( EV_REQUEST * req, FIELDSYS_WORK * repw, u16 trg, u16 cont )
 			}
 			if( trg & PAD_BUTTON_CANCEL ){
 				req->FloatCheck = TRUE;
+			}
+			if( trg & PAD_BUTTON_R ){
+				req->OpenPCCheck = TRUE;
 			}
 //		}
 		if( cont & ALL_KEY ){
@@ -655,6 +659,10 @@ int CheckRequest(const EV_REQUEST * req, FIELDSYS_WORK * repw)
 		    FieldMenuInit( repw );
 			return TRUE;
 		}
+	}
+	if( req->OpenPCCheck ){
+		EventSet_Script(repw, SCRID_PC_ON, NULL);
+		return TRUE;
 	}
 #ifdef	PM_DEBUG
 	// í“¬ƒeƒXƒg‚Ö

--- a/src/field/ev_check.h
+++ b/src/field/ev_check.h
@@ -34,7 +34,8 @@ typedef struct {
 	u16	DebugBattle:1;
 	u16	DebugHook:1;
 	u16 DebugKeyPush:1;
-	u16	:4;
+	u16 OpenPCCheck:1;
+	u16	:3;
 
 	u8	Site;
 	s8	PushSite;


### PR DESCRIPTION
Add the Pc anywhere (or box link whatev you name it) to the R button. Currently crashes in ANY area that does not has a PC in it (so any area that is not a Pokemon Center). It is fixed locally using DS Pokemon ROM Editor, need to find a way to commit the change over. Please make suggestion for this 